### PR TITLE
Fix 2 typos

### DIFF
--- a/snapshot/pkg/apis/volumesnapshot/v1/types.go
+++ b/snapshot/pkg/apis/volumesnapshot/v1/types.go
@@ -75,7 +75,7 @@ type VolumeSnapshotCondition struct {
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// VolumeSnapshot is the volume snapshot object accessible to the user. Upon succesful creation of the actual
+// VolumeSnapshot is the volume snapshot object accessible to the user. Upon successful creation of the actual
 // snapshot by the volume provider it is bound to the corresponding VolumeSnapshotData through
 // the VolumeSnapshotSpec
 type VolumeSnapshot struct {
@@ -117,7 +117,7 @@ type VolumeSnapshotDataStatus struct {
 	// +optional
 	CreationTimestamp metav1.Time `json:"creationTimestamp" protobuf:"bytes,1,opt,name=creationTimestamp"`
 
-	// Representes the lates available observations about the volume snapshot
+	// Represents the lates available observations about the volume snapshot
 	Conditions []VolumeSnapshotDataCondition `json:"conditions" protobuf:"bytes,2,rep,name=conditions"`
 }
 


### PR DESCRIPTION
"succesful" is a misspelling of "successful"
"Representes" is a misspelling of "Represents"